### PR TITLE
Lots of changes

### DIFF
--- a/text/0000-stabilize-arbitrary-self-types.md
+++ b/text/0000-stabilize-arbitrary-self-types.md
@@ -101,7 +101,7 @@ where
 }
 ```
 
-and for both mutable and immutable references.
+A implementation is provided for both mutable and immutable references.
 
 The existing Rust [reference section for method calls describes the algorithm assuming that the prior version of `arbitrary_self_types` was stabilized](https://doc.rust-lang.org/reference/expressions/method-call-expr.html), so isn't 100% accurate for the current state of stable Rust.
 

--- a/text/0000-stabilize-arbitrary-self-types.md
+++ b/text/0000-stabilize-arbitrary-self-types.md
@@ -147,7 +147,28 @@ Since `DispatchFromDyn` is unstable at the moment, object-safe receivers might b
 
 ## Lifetime Elision
 
-TODO
+As discussed in the [motivation](#motivation), this new facility is most likely
+to be used in cases where a standard reference can't normally be used. But
+the self type might wrap a standard Rust reference, and thus might be
+parameterized by a lifetime.
+
+This works just fine:
+
+```rust
+struct SmartPtr<'a, T: ?Sized>(&'a T);
+
+impl<'a, T: ?Sized> Receiver for SmartPtr<'a, T> {
+    type Target = T;
+}
+
+struct MyType;
+
+impl MyType {
+    fn m(self: SmartPtr<Self>) {}
+    fn n(self: SmartPtr<'_, Self>) {}
+    fn o<'a>(self: SmartPtr<'a, Self>) {}
+}
+```
 
 ## Diagnostics
 

--- a/text/0000-stabilize-arbitrary-self-types.md
+++ b/text/0000-stabilize-arbitrary-self-types.md
@@ -227,6 +227,20 @@ to exist, any option for implementing `Deref::deref` has drawbacks:
   reference - this isn't the case for (for instance) weak pointers or types
   containing `NonNull`.
 
+## No blanket implementation for `Deref`
+
+The other major approach previously discussed is to have a `Receiver` trait,
+as proposed in this RFC, but without a blanket implementation for `T: Deref`.
+An advantage would be the ability for a type to determine independently whether
+it should be dereferenceable and/or a method receiver. But no known use-case
+exists, and it would be confusing to have distinct chains for dereferencing
+and method calls. Implementing `Receiver` for `T: Deref` seems a powerful move
+to reduce user confusion.
+
+(A further suggestion had been to provide separate `Receiver` and `Deref` traits
+yet have the method resolution logic explore both. This seems to offer no
+advantages over the blanket implementation, and gives a worst-case O(n*m) number
+of method candidates).
 
 ## Generic parameter
 

--- a/text/0000-stabilize-arbitrary-self-types.md
+++ b/text/0000-stabilize-arbitrary-self-types.md
@@ -464,9 +464,11 @@ and was postponed with the expectation that the lang team would [get back to `ar
     This fails, because `T: Receiver<Target=T>` generally does not hold.
     An alternative would be to lift the associated type into a generic type parameter of the `Receiver` trait, that would allow adding a blanket `impl Receiver<T> for T` without overlap.
 - This sinister TODO is present in the code:
+    ```
                 // FIXME(arbitrary_self_types): We probably should limit the
                 // situations where this can occur by adding additional restrictions
                 // to the feature, like the self type can't reference method substs.
+    ```
 
 # Feature gates
 

--- a/text/0000-stabilize-arbitrary-self-types.md
+++ b/text/0000-stabilize-arbitrary-self-types.md
@@ -11,14 +11,15 @@ Allow types that implement the new `trait Receiver<Target=Self>` to be the recei
 # Motivation
 [motivation]: #motivation
 
-Today, methods can only be received by value, by reference, by mutable reference, or by one of a few blessed smart pointer types from `libstd` (`Arc<Self>`, `Box<Self>`, `Pin<Self>` and `Rc<Self>`).
-This has always intended to be generalized to support any kind of pointer, such as an `CustomPtr<Self>`. Since late 2017, it has been available on nightly under the `arbitrary_self_types` feature for types that implement `Deref<Target=Self>`.
+Today, methods can only be received by value, by reference, or by one of a few blessed smart pointer types from `core`, `alloc` and `std` (`Arc<Self>`, `Box<Self>`, `Pin<Self>` and `Rc<Self>`).
 
-Because different kinds of "smart pointers" can constrain the semantics in non trivial ways, traits can rely on certain assumptions about the receiver of their method. Just implementing the trait *for* a smart pointer doesn't allow that kind of reliance.
+It's been assumed that this will eventually be generalized to support any smart pointer, such as an `CustomPtr<Self>`. Since late 2017, it has been available on nightly under the `arbitrary_self_types` feature for types that implement `Deref<Target=Self>` and for raw pointers.
 
-One relevant use-case is cross-language interop (JavaScript, Python, C++), where other languages' equivalents can’t guarantee the aliasing semantics required of a Rust reference. Another case is when the existence of a reference to a thing is, itself, meaningful — for example, reference counting, or if relayout of a UI should occur each time a mutable reference ceases to exist.
+One relevant use-case is cross-language interop (JavaScript, Python, C++), where other languages' references can’t guarantee the aliasing and exclusivity semantics required of a Rust reference. For example, the C++ `this` pointer can't be practically or safely represented as a Rust reference because C++ may retain other pointers to the data and it might mutate at any time. Yet, calling C++ methods intrinsically requires a `this` reference.
 
-In theory, users can define their own smart pointers. In practice, they're second-class citizens compared to the smart pointers in Rust's standard library. User-defined smart pointers to `T` can accept method calls only if the receiver (`self`) type is `&T` or `&mut T`, which causes us to run right into the "reference semantics are not right" problem that we were trying to avoid.
+Another case is when the existence of a reference is, itself, semantically important — for example, reference counting, or if relayout of a UI should occur each time a mutable reference ceases to exist. In these cases it's not OK to allow a regular Rust reference to exist, and yet sometimes we still want to be able to call methods on a reference-like thing.
+
+In theory, users can define their own smart pointers. In practice, they're second-class citizens compared to the smart pointers in Rust's standard library. User-defined smart pointers to `T` can accept method calls only if the receiver (`self`) type is `&T` or `&mut T`, which isn't acceptable when we can't safely create native Rust references to a `T`.
 
 This RFC proposes to loosen this restriction to allow custom smart pointer types to be accepted as a `self` type just like for the standard library types.
 
@@ -32,25 +33,21 @@ When declaring a method, users can declare the type of the `self` receiver to be
 The `Receiver` trait is simple and only requires to specify the `Target` type to be resolved to:
 
 ```rust
-/// # SAFETY
-/// - the type needs to be ABI-compatible with a fat pointer
 trait Receiver {
     type Target: ?Sized;
 }
 ```
 
-
 The `Receiver` trait is already implemented for a few types from the standard, i.e.
-- smart pointer: `Arc<Self>`, `Box<Self>`, `Pin<Self>` and `Rc<Self>`
+- smart pointers: `Rc<Self>`, `Arc<Self>`, `Box<Self>`, and `Pin<Ptr<Self>>`, because these types all implement `Deref` and there's a blanket implementation of `Receiver` for `Deref`.
 - references: `&Self` and `&mut Self`
-- raw pointer: `*const Self` and `*mut Self`
 
 Shorthand exists for references, so that `self` with no ascription is of type `Self`, `&self` is of type `&Self` and `&mut self` is of type `&mut Self`.
 
 All of the following self types are valid:
 
 ```rust
-trait Foo {
+impl Foo {
     fn by_value(self /* self: Self */);
     fn by_ref(&self /* self: &Self */);
     fn by_ref_mut(&mut self /* self: &mut Self */);
@@ -81,7 +78,10 @@ impl MyType {
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 
-The `Receiver` trait is made public (removing its `#[doc(hidden)])` attribute), exposing it under `core::ops`.
+## `core` libs changes
+
+The `Receiver` trait is made public (removing its `#[doc(hidden)])` attribute), exposing it under `core::ops`. It adds a `Target` associated type.
+
 This trait marks types that can be used as receivers other than the `Self` type of an impl or trait definition.
 
 ```rust
@@ -90,33 +90,52 @@ pub trait Receiver {
 }
 ```
 
-For a type to be a valid receiver for a given impl, the `Self` type of the impl or trait has to appear in its receiver chain.
+A blanket implementation is provided for any type that implements `Deref`:
 
-The receiver chain is constructed as follows:
-1. Add the receiver type `T` to the chain.
-2. If `T` implements `Receiver`, add `<T as Receiver>::Target` to the chain.
-3. Repeat step 2 with the `<T as Receiver>::Target` as `T`.
+```rust
+impl<P: ?Sized, T: ?Sized> Receiver for P
+where
+    P: Deref<Target = T>,
+{
+    type Target = T;
+}
+```
 
-## Method Resolution
+and for both mutable and immutable references.
 
-Method resolution will be adjusted to take into account a receiver's receiver chain by taking looking through all impls for all types appearing in the receiver chain.
+The existing Rust [reference section for method calls describes the algorithm assuming that the prior version of `arbitrary_self_types` was stabilized](https://doc.rust-lang.org/reference/expressions/method-call-expr.html), so isn't 100% accurate for the current state of stable Rust.
 
-> [@adetaylor] I think we need more detail here about how this interacts with `autoderef.rs` within the method resolution process. At every step of the (arbitrarily long) `Autoderef` chain, it feels like we'll now explore an (arbitrarily long) `Receiver` chain, which would result in an O(n^2) number of possible method candidates. That can't be OK.
-> Alternatively, do we intend to get all the way through the `Autoderef` chain before starting on the `Receiver` chain?
+To summarize the algorithms in all three states:
 
-## core lib changes
+## Without `arbitrary_self_types` or this new `Receiver` trait
 
-The implementations of the hidden `Receiver` trait will be adjusted by removing the `#[doc(hidden)]` attribute and having their corresponding `Target` associated type added.
+This is the current status in stable Rust.
 
-The trait will be implemented for following types
-- Arc
-- Box
-- Pin
-- Rc
-- &
-- &mut
-- Weak
-- TODO...
+A possible list of candidate types is created by:
+
+1. Deref the receiver expression's type repeatedly, until we encounter any type that doesn't implement the hidden `Receiver` trait (`Self`, `&Self`, `&mut Self`, `Rc<Self>`, `Arc<Self>`, `Box<Self>`, and `Pin<Ptr<Self>>`)
+2. Finally attempt an unsized coercion
+3. For each type, consider `T`, `&T` and `&mut T`
+
+## With the previous `arbitrary_self_types`
+
+This is the status as described in the existing reference.
+
+A possible list of candidate types is created by:
+
+1. Deref the receiver expression's type repeatedly (allowing dereferencing steps via raw pointers too)
+2. Finally attempt an unsized coercion
+3. For each type, consider `T`, `&T` and `&mut T`
+
+## With this new `Receiver` trait
+
+A possible list of candidate types is created by:
+
+1. Follow the chain of `Receiver` targets (that is, if `T` implements `Receiver`, add `<T as Receiver>::Target` to the chain)
+2. Finally attempt an unsized coercion
+3. For each type, consider `T`, `&T` and `&mut T`
+
+Because there is a blanket implementation of `Receiver` for `Deref`, this new algorithm is very similar to the previous `arbitrary_self_types`. The differences are (a) we don't allow dereferencing steps via raw pointers, (b) `Receiver` can be implemented by types that don't implement `Deref`.
 
 ## Object safety
 
@@ -132,79 +151,155 @@ TODO
 
 ## Diagnostics
 
-TODO ensure we include some analysis of extra diagnostics required. Known gotchas:
+The existing branches in the compiler for "arbitrary self types" already emit
+excellent diagnostics. We will simply re-use them.
+
+TODO
+
+- Ensure we update the messages produced by these diagnostics to mention the possibility of implementing `Receiver` rather than just listing the hard-coded types
 - In a trait, using `self: SomeSmartPointerWhichOnlySupportsSizedTypes<Self>` without using `where Self: Sized` on the trait definition results in poor diagnostics.
+- If people try to call a method on a `P<T>` where `P: !Receiver` and `T` has such a method, we could provide a suggestion that `P` implement `Receiver`. However, it's expected that `Receiver` is a fairly niche trait and such diagnostics could possibly cause over-use. We should consider this with the benefit of experience.
+- If people try to use  `*const T`, `*mut T`, `Weak` or `NotNull` as a self type, explain that these types do not implement `Receiver` so method calls are not possible. Suggest that the type could be wrapped in a newtype wrapper which implements `Receiver`
 
 # Drawbacks
 [drawbacks]: #drawbacks
 
 Why should we *not* do this?
 
-- Implementations of this trait may obscure what method is being called where in similar ways to deref coercions obscuring it.
-- The use of this feature together with `Deref` implementations may cause ambiguious situations. Invoking `Ptr(Bar).foo()` will require the use of fully qualified paths (`Bar::foo` vs `Ptr::foo` or `Ptr::<T>::foo`) to disambiguate the call.
-    ```rs
-    use std::ops::{Deref, Receiver};
+- Deref coercions can already be confusing and unexpected. `Deref` becomes more powerful and significant if it allows method calls.
+- If a smart pointer type `P` implements `Deref<Target=T>`, it may well be used to allow method calls on `T` using `fn m(self: P<T>)`
+  and similar. This effectively constrains the subsequent implementation of `P`, because any new methods added to `P` are a
+  compatibility break - more details in the Method Shadowing section, below.
+- Custom smart pointers are a niche use case (but they're very important for cross-language interoperability.)
 
-    pub struct Ptr<T>(T);
+## Method shadowing
+[method-shadowing]: #method-shadowing
 
-    impl<T> Deref for Ptr<T> {
-        type Target = T;
+Currently for a smart pointer `P`, a method call `p.m()` can only possibly call
+a method on that smart pointer type itself - `P::m`.
 
-        fn deref(&self) -> &T {
-            &self.0
-        }
-    }
+With arbitrary self types, and assuming `P: Receiver<Target=T>`, it's possible that
+the method call could be `P::m` or `T::m`.
 
-    impl Receiver for Ptr<T> {
-        type Target = T;
-    }
+It's assumed that smart pointers can't usually predict the possible types to
+which they refer (`T`) and so the creator of `P` cannot know in advance what
+`T` methods may exist.
 
-    impl<T> Ptr<T> {
-        pub fn foo(&self) {
-            println!("hip")
-        }
-    }
+This effectively means that adding extra methods to `P` is a possible
+compatibility break, because `P` might shadow methods already in `T`.
 
-    pub struct Bar;
-
-    impl Bar {
-        fn foo(self: &Ptr<Self>) {
-            println!("hop")
-        }
-    }
-
-    fn main() {
-        let a = Ptr(Bar);
-        a.foo(); // hip or hop? error[E0034]: multiple applicable items in scope
-        Ptr::foo(a); // hip
-        Bar::foo(a); // hop
-    }
-    ```
+Fortunately, the Rust standard library smart pointer types were already designed
+with this in mind - `Box`, `Pin`, `Rc` and `Arc` already heavily use associated
+functions rather than methods. The same approach should be taken by custom smart
+pointers. But this does mean that it's difficult to adopt "arbitrary self types"
+for existing smart pointer types unless they were designed with this in mind.
 
 # Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives
 
 ## Deref-based
 
-The current `Deref`-based implementation is not sufficient, because there are types which can not implement `Deref`, but would be good candidates to be used as self types (for example raw pointers). Therefore there is a need for the `Receiver` trait.  (See [below](#prior-art) for more details of the trade-offs.)
+Unstable Rust contains an implementation of arbitrary self types based around the
+`Deref` trait.
 
-In theory we could use both traits, so a type can be used as a receiver if it implements `Deref` or `Receiver`. All the types that can implement `Deref` do so. All the types that cannot implement `Deref` implement `Receiver`. There could be a blanked implementation `impl<T> Receiver for T where T: Deref`. 
+However, if it's OK to create a reference `&T`, you probably don't need this feature.
+You can probably simply use `&self` as your receiver type.
 
-The advantage of that would be, that there is a vast amount of types that implement `Deref` today, which then could immediately be used as self types.
+This feature is fundamentally aimed at smart pointer types `P<T>` where it's not safe
+to create a reference `&T`. As discussed in the rationale, that's most commonly
+because of semantic differences to pointers in other languages, but it might be
+because references have special meaning or behavior in some pure Rust domain.
+Either way, it's not OK to create a Rust reference `&T` or `&mut T`, yet we
+may want to allow methods to be called on some reference-like thing.
 
-But there are some concerns with using both traits.
-Firstly, it makes the feature more complicated, because it is not one, but two traits and it might be unclear when to choose which of the two.
-Secondly, since so many types already implement `Deref`, adding functionality to it (in this case enabling types as method receivers) bears the risk of breaking someones types. But so far we could not identify any possiblities where this would be the case.
+For this reason, implementing `Deref::deref` is problematic for nearly everyone
+who wants to use arbitrary self types.
+
+If you're implementing a smart pointer `P<T>` yet you can't allow a reference `&T`
+to exist, any option for implementing `Deref::deref` has drawbacks:
+
+* Specify `Deref::Target=T` and panic in `Deref::deref`. Not good.
+* Specify `Deref::Target=*const T`. This works with the current arbitrary self
+  types feature, but that's because the current feature allows intermediate
+  steps of raw pointers, and we don't think we can stabilize that due to the
+  [method shadowing concerns discussed higher up](#method-shadowing). In any case, this is only
+  possible if your smart pointer type contains a `*const T` which you can
+  reference - this isn't the case for (for instance) weak pointers or types
+  containing `NonNull`.
+
 
 ## Generic parameter
 
-Change the trait definition to have a generic parameter instead of an associated type:
+Change the trait definition to have a generic parameter instead of an associated type.
+There might be permutations here which could allow a single smart pointer type
+to dispatch method calls to multiple possible receivers - but this would add
+complexity, no known use case exists, and it might cause worst-case O(n^2)
+performance on method lookup.
+
+## Enable for pointers too
+
+The current unstable `arbitrary_self_types` feature also allows dispatch
+directly onto raw pointers:
 
 ```rust
-pub trait Receiver<T: ?Sized> {}
+impl Foo {
+    fn method(self: *const Self) {
+        // ...
+    }
+}
 ```
 
-to allow an impl of the form `impl Receiver<T> for T`. This would enable `Self` to be used as is by the trait impl rule instead of a special case.
+However, we do not propose to stabilize this because of the concerns mentioned in
+the [method Shadowing section](#method-shadowing).
+
+## Enable for pointers with additional diagnostics
+
+Elsewhere in Rust, there are already diagnostics saying
+> a method with this name may be added to the standard library in the future
+and warning about the consequences.
+
+If we chose to stabilize arbitrary self types for raw pointers too, we could
+simply warn that _any_ use of a raw pointer as a self type could be subject
+to future shadowing by standard library. But, that would essentially make
+this feature perpetually warny for raw pointers, so it seems better to just
+remove it.
+
+## Enable for pointers behind an unstable flag
+
+The current unstable `arbitrary_self_types` feature _does_ allow method dispatch
+on raw pointers. For anyone relying on that, this is a breakage. We could
+add that facility behind an alternative unstable flag.
+
+However, as discussed under [method Shadowing section](#method-shadowing) this
+would prevent Rust from ever adding more methods to the raw pointer primitive
+type. That doesn't feel like it will be OK, and so there is no known path
+to stabilizing raw pointer self types. Therefore, we choose to just remove
+this facility.
+
+## Allow implementation of `Receiver` for foreign types
+
+An alternative workaround for the removal of this "raw pointer self type"
+facility is to allow explicit implementation of `Receiver` for raw pointers.
+
+```rust
+impl Receiver for *const MyType {
+    type Target = MyType;
+}
+```
+
+This currently falls foul of the orphan rule. We could add an exception
+just as we have for [traits parameterized by local types](https://blog.rust-lang.org/2020/01/30/Rust-1.41.0.html#relaxed-restrictions-when-implementing-traits)
+but this would be complex in itself.
+
+## Implement for `Weak` and `NonNull`
+
+`Weak<T>` and `NonNull<T>` were not supported by the prior unstable arbitrary self tpes
+support, but they share the property that it may be desirable to implement
+method calls to `T` using them as self types. Unfortunately they also share the property that these types
+have many Rust methods. If we added to the set of Rust methods in future,
+we'd [shadow any such method calls](#method-shadowing). We can't implement `Receiver` for these types unless
+we come up with a policy that all subsequent additions to these types would
+instead be associated functions.
 
 ## Not do it
 
@@ -263,7 +358,6 @@ fn main() {
     a.m();
     a.tm();
 }
-
 ```
 
 This successfully allows method calls to `m()` and even `tm()` without a reference to a `SomeCppType` ever existing.
@@ -271,37 +365,49 @@ However, due to the orphan rule, this forces `SomeCppType` to be in the same cra
 has been used by some C++ interop tools, but results in complex function signatures in all downstream code
 (`impl CppPtr<Pointee=SomeCppType>` all over the place).
 
+## Always use `unsafe` when interacting with other languages
+
+One main motivation here is cross-language interoperability. As noted in the rationale,
+C++ references can't be _safely_ represented by Rust references. Some would say that all C++
+interop is intrinsically unsafe and that `unsafe` blocks are required. But that doesn't
+solve the problem - an `unsafe` block requires a human to assert preconditions are met,
+e.g. that there are no other C++ pointers to the same data. But those preconditions are
+almost never true, because other languages don't have those rules. This means that a C++ reference
+can never be a Rust reference, because neither human nor computer can promise
+things that aren't true.
+
+Only in the very simplest interop scenarios can we claim that a human could
+audit all the C++ code to eliminate the risk of other pointers exisitng. In
+complex projects, that's not possible.
+
+However, a C++ reference _can_ be passed through Rust safely as an opaque token
+such that method calls can be performed on it. Those method calls actually happen
+back in the C++ domain where aliasing and concurrent modification are "fine".
+
+For instance,
+
+```rust
+struct CppRef<T>;
+
+fn main() {
+    let some_cpp_reference: CppRef<_> = CallSomeCppFunctionToGetAReference();
+    // There may be other C++ references to the referent, with concurrent
+    // modification, so some_cpp_reference can't be a &T
+    // But we still want to be able to do this
+    some_cpp_reference.SomeCppMethod(); // executes in C++. Data is not
+        // dereferenced at all in Rust.
+}
+```
 
 # Prior art
 [prior-art]: #prior-art
 
-A previous PR based on the `Deref` alternative has been proposed before https://github.com/rust-lang/rfcs/pull/2362.
-
-The present proposal uses the `Receiver` trait instead of using this `Deref`-based approach for the following reasons.
-
-* For a given use case, if it's OK to create references `&T` to a type `T`, then users can receive method calls as `&T` - and there's no need for custom receiver types. The `Receiver` trait is, almost by definition, useful only in cases where `&T` is harmful. Using `Deref` implies creation of a reference, and is therefore harmful, or at least very confusing.
-* `Deref` already has a meaning, and giving additional meaning to `Deref` could be regarded as a semantic compatibility break (even though it isn't a source code compatibility break, as any methods with custom receivers would not currently compile)
-
-TODO:
-
-Discuss prior art, both the good and the bad, in relation to this proposal.
-A few examples of what this can include are:
-
-- For language, library, cargo, tools, and compiler proposals: Does this feature exist in other programming languages and what experience have their community had?
-- For community proposals: Is this done by some other community and what were their experiences with it?
-- For other teams: What lessons can we learn from what other communities have done here?
-- Papers: Are there any published papers or great posts that discuss this? If you have some relevant papers to refer to, this can serve as a more detailed theoretical background.
-
-This section is intended to encourage you as an author to think about the lessons from other languages, provide readers of your RFC with a fuller picture.
-If there is no prior art, that is fine - your ideas are interesting to us whether they are brand new or if it is an adaptation from other languages.
-
-Note that while precedent set by other languages is some motivation, it does not on its own motivate an RFC.
-Please also take into consideration that rust sometimes intentionally diverges from common language features.
+A previous PR based on the `Deref` alternative has been proposed before https://github.com/rust-lang/rfcs/pull/2362
+and was postponed with the expectation that the lang team would [get back to `arbitrary_self_types` eventually](https://github.com/rust-lang/rfcs/pull/2362#issuecomment-527306157).
 
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions
 
-- There is the option of doing a blanket impl of the `Receiver` trait based on `Deref` impls delegating the `Target` types.
 - With the proposed design, it is not possible to be generic over the receiver while permitting the plain `Self` to be slotted in:
     ```rs
     use std::ops::Receiver;
@@ -320,22 +426,11 @@ Please also take into consideration that rust sometimes intentionally diverges f
     ```
     This fails, because `T: Receiver<Target=T>` generally does not hold.
     An alternative would be to lift the associated type into a generic type parameter of the `Receiver` trait, that would allow adding a blanket `impl Receiver<T> for T` without overlap.
+- This sinister TODO is present in the code:
+                // FIXME(arbitrary_self_types): We probably should limit the
+                // situations where this can occur by adding additional restrictions
+                // to the feature, like the self type can't reference method substs.
 
-- Should this work for (statically resolved) trait method calls? e.g.
-  ```rs
-  use std::ops::Receiver;
-  struct CustomPtr<T>(T);
-  impl<T> Receiver for CustomPtr<T> {
-    type Target = T;
-  }
-  trait Foo {
-     fn bar(self: CustomPtr<Self>);
-  }
-  struct Baz;
-  impl Foo for Baz {
-    fn bar(self: CustomPtr<Self>) {}
-  }
-  ```
 
 # Future possibilities
 [future-possibilities]: #future-possibilities

--- a/text/0000-stabilize-arbitrary-self-types.md
+++ b/text/0000-stabilize-arbitrary-self-types.md
@@ -39,7 +39,7 @@ trait Receiver {
 ```
 
 The `Receiver` trait is already implemented for a few types from the standard, i.e.
-- smart pointers: `Rc<Self>`, `Arc<Self>`, `Box<Self>`, and `Pin<Ptr<Self>>`, because these types all implement `Deref` and there's a blanket implementation of `Receiver` for `Deref`.
+- smart pointers: `Rc<Self>`, `Arc<Self>`, `Box<Self>`, and `Pin<Ptr<Self>>`
 - references: `&Self` and `&mut Self`
 
 Shorthand exists for references, so that `self` with no ascription is of type `Self`, `&self` is of type `&Self` and `&mut self` is of type `&mut Self`.

--- a/text/0000-stabilize-arbitrary-self-types.md
+++ b/text/0000-stabilize-arbitrary-self-types.md
@@ -333,7 +333,7 @@ but this would be complex in itself.
 `Weak<T>` and `NonNull<T>` were not supported by the prior unstable arbitrary self tpes
 support, but they share the property that it may be desirable to implement
 method calls to `T` using them as self types. Unfortunately they also share the property that these types
-have many Rust methods. If we added to the set of Rust methods in future,
+have many Rust methods using `self`, `&self` or `&mut self`. If we added to the set of Rust methods in future,
 we'd [shadow any such method calls](#method-shadowing). We can't implement `Receiver` for these types unless
 we come up with a policy that all subsequent additions to these types would
 instead be associated functions.

--- a/text/0000-stabilize-arbitrary-self-types.md
+++ b/text/0000-stabilize-arbitrary-self-types.md
@@ -486,10 +486,10 @@ disruptive way to stabilize this feature.
 Options are:
 
 * Use the `receiver_trait` feature gate until we stabilize this. Remove
-  the `arbitrary_self_types` feature gate. Later, stabilize this and remove
+  the `arbitrary_self_types` feature gate immediately. Later, stabilize this and remove
   `receiver_trait` too.
 * Use the `arbitrary_self_types` feature gate until we stabilize this. Remove
-  the `receiver_trait` feature gate. Later, stabilize this and remove
+  the `receiver_trait` feature gate immediately. Later, stabilize this and remove
   `arbitrary_self_types` too.
 * Invent a new feature gate.
 * Immediately stabilize this without any feature gate, and remove both
@@ -498,6 +498,11 @@ Options are:
 It seems potentially confusing to alter the semantics of the already-used
 `arbitrary_self_types` feature gate, so this RFC proposes the first course
 of action.
+
+We propose that this feature be available behind the `receiver_trait` feature
+gate for two releases, prior to being fully stabilized. That should allow
+enough time for existing users of `arbitrary_self_types` to adapt and report
+any concerns.
 
 # Future possibilities
 [future-possibilities]: #future-possibilities

--- a/text/0000-stabilize-arbitrary-self-types.md
+++ b/text/0000-stabilize-arbitrary-self-types.md
@@ -283,8 +283,11 @@ impl Foo {
 }
 ```
 
-However, we do not propose to stabilize this because of the concerns mentioned in
-the [method Shadowing section](#method-shadowing).
+However, we do not propose to stabilize this. For once because of the concerns
+mentioned in the [method Shadowing section](#method-shadowing). Secondly
+because we do not want to encourage the use of raw pointers, but rather that
+raw pointers are wrapped in a custom smart pointer that encodes and documents
+the invariants.
 
 ## Enable for pointers with additional diagnostics
 

--- a/text/0000-stabilize-arbitrary-self-types.md
+++ b/text/0000-stabilize-arbitrary-self-types.md
@@ -118,6 +118,7 @@ A possible list of candidate types is created by:
 3. For each type, consider `T`, `&T` and `&mut T`
 
 ## With the previous `arbitrary_self_types`
+[previous-self-types]: #previous-self-types
 
 This is the status as described in the existing reference.
 
@@ -466,6 +467,37 @@ and was postponed with the expectation that the lang team would [get back to `ar
                 // situations where this can occur by adding additional restrictions
                 // to the feature, like the self type can't reference method substs.
 
+# Feature gates
+
+This RFC is in an unusual position regarding feature gates. There are two
+existing gates:
+
+- `arbitrary_self_types` enables, roughly, the _semantics_ we're proposing,
+  albeit [in a different way](#with-the-previous-arbitrary_self_types) and with
+  support for raw pointers as self types. It has been used by various projects.
+- `receiver_trait` enables the specific trait we propose to use, albeit
+  without the `Target` associated type. It has only been used within the Rust
+  standard library, as far as we know.
+
+Although we presumably have no obligation to maintain compatibility for users
+of the unstable `arbitrary_self_types` feature, we should consider the least
+disruptive way to stabilize this feature.
+
+Options are:
+
+* Use the `receiver_trait` feature gate until we stabilize this. Remove
+  the `arbitrary_self_types` feature gate. Later, stabilize this and remove
+  `receiver_trait` too.
+* Use the `arbitrary_self_types` feature gate until we stabilize this. Remove
+  the `receiver_trait` feature gate. Later, stabilize this and remove
+  `arbitrary_self_types` too.
+* Invent a new feature gate.
+* Immediately stabilize this without any feature gate, and remove both
+  `arbitrary_self_types` and `receiver_trait`
+
+It seems potentially confusing to alter the semantics of the already-used
+`arbitrary_self_types` feature gate, so this RFC proposes the first course
+of action.
 
 # Future possibilities
 [future-possibilities]: #future-possibilities


### PR DESCRIPTION
Primarily, writing up based on experience of trying to implement this twice:
- once just stabilizing the existing `Deref` approach
- once by adding the `Receiver` trait and a blanket impl for `Deref`

plus just lots of thinking and writing about it.

The only major substantive change here is that I propose we do NOT stabilize the use of raw pointers as self types. For the reasons described, I don't see any path to ever stabilizing this, and we should remove it.