### PR TITLE
Remove first unresolved question.

### DIFF
--- a/text/0000-stabilize-arbitrary-self-types.md
+++ b/text/0000-stabilize-arbitrary-self-types.md
@@ -445,24 +445,6 @@ and was postponed with the expectation that the lang team would [get back to `ar
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions
 
-- With the proposed design, it is not possible to be generic over the receiver while permitting the plain `Self` to be slotted in:
-    ```rs
-    use std::ops::Receiver;
-
-    struct Foo(u32);
-    impl Foo {
-        fn get<R: Receiver<Target=Self>>(self: R) -> u32 {
-            self.0
-        }
-    }
-
-    fn main() {
-        let mut foo = Foo(1);
-        foo.get::<&Foo>(); // Error
-    }
-    ```
-    This fails, because `T: Receiver<Target=T>` generally does not hold.
-    An alternative would be to lift the associated type into a generic type parameter of the `Receiver` trait, that would allow adding a blanket `impl Receiver<T> for T` without overlap.
 - This sinister TODO is present in the code:
     ```
                 // FIXME(arbitrary_self_types): We probably should limit the


### PR DESCRIPTION
@Veykril, hello!

I can't find any problems or quirks here. Please see the amendments to the test here:
https://github.com/adetaylor/rust/commit/ceb5918ec65

The amended test now passes against our latest branch (which adds a `Target` trait to `Receiver` as proposed in the RFC), and seems to behave exactly as I'd want. If you still believe there are problems here please could you explain a bit more?