### PR TITLE
Avoid the word "stabilize"

### DIFF
--- a/text/0000-arbitrary-self-types-v2.md
+++ b/text/0000-arbitrary-self-types-v2.md
@@ -247,7 +247,7 @@ Change the trait definition to have a generic parameter instead of an associated
 
 It would be possible to respect the `Receiver` trait without allowing dispatch onto raw pointers - they are essentially independent changes to the candidate deduction algorithm.
 
-We don't want to encourage the use of raw pointers, and would prefer rather that raw pointers are wrapped in a custom smart pointer that encodes and documents the invariants. So, there's an argument not to stabilize the raw pointer support.
+We don't want to encourage the use of raw pointers, and would prefer rather that raw pointers are wrapped in a custom smart pointer that encodes and documents the invariants. So, there's an argument not to add the raw pointer support.
 
 However, the current unstable `arbitrary_self_types` feature provides support for raw pointer receivers, and with years of experience no major concerns have been spotted. We would prefer not to deviate from the existing proposal more than necessary. Moreover, we are led to believe that raw pointer receivers are quite important for the future of safe Rust, because stacked borrows makes it illegal to materialize references in many positions, and there are a lot of operations (like going from a raw pointer to a raw pointer to a field) where users don't need to or want to do that. We think the utility of including raw pointer receivers outweighs the risks of tempting people to over-use raw pointers.
 
@@ -357,7 +357,7 @@ This RFC is in an unusual position regarding feature gates. There are two existi
 - `arbitrary_self_types` enables, roughly, the _semantics_ we're proposing, albeit [in a different way](#deref-based). It has been used by various projects.
 - `receiver_trait` enables the specific trait we propose to use, albeit without the `Target` associated type. It has only been used within the Rust standard library, as far as we know.
 
-Although we presumably have no obligation to maintain compatibility for users of the unstable `arbitrary_self_types` feature, we should consider the least disruptive way to stabilize this feature.
+Although we presumably have no obligation to maintain compatibility for users of the unstable `arbitrary_self_types` feature, we should consider the least disruptive way to introduce this feature.
 
 Options are:
 

--- a/text/0000-stabilize-arbitrary-self-types.md
+++ b/text/0000-stabilize-arbitrary-self-types.md
@@ -367,8 +367,6 @@ Options are:
 
 This RFC proposes the first course of action, since `arbitrary_self_types` is used externally and we think all currently use-cases should continue to work.
 
-We propose that this feature be available behind the `arbitrary_self_types` feature gate for two releases, prior to being fully stabilized. That should give time for any problems with our `Receiver`-based implementation to be reported.
-
 # Summary
 
 This RFC is an example of replacing special casing aka. compiler magic with clear and transparent definitions. We believe this is a good thing and should be done whenever possible.

--- a/text/0000-stabilize-arbitrary-self-types.md
+++ b/text/0000-stabilize-arbitrary-self-types.md
@@ -364,7 +364,6 @@ Options are:
 * Use the `arbitrary_self_types` feature gate until we stabilize this. Remove the `receiver_trait` feature gate immediately. Later, stabilize this and remove `arbitrary_self_types` too.
 * Use the `receiver_trait` feature gate until we stabilize this. Remove the `arbitrary_self_types` feature gate immediately. Later, stabilize this and remove `receiver_trait` too.
 * Invent a new feature gate.
-* Immediately stabilize this without any feature gate, and remove both `arbitrary_self_types` and `receiver_trait`
 
 This RFC proposes the first course of action, since `arbitrary_self_types` is used externally and we think all currently use-cases should continue to work.
 

--- a/text/0000-stabilize-arbitrary-self-types.md
+++ b/text/0000-stabilize-arbitrary-self-types.md
@@ -361,8 +361,8 @@ Although we presumably have no obligation to maintain compatibility for users of
 
 Options are:
 
-* Use the `arbitrary_self_types` feature gate until we stabilize this. Remove the `receiver_trait` feature gate immediately. Later, stabilize this and remove `arbitrary_self_types` too.
-* Use the `receiver_trait` feature gate until we stabilize this. Remove the `arbitrary_self_types` feature gate immediately. Later, stabilize this and remove `receiver_trait` too.
+* Use the `arbitrary_self_types` feature gate, and remove the `receiver_trait` feature gate immediately.
+* Use the `receiver_trait` feature gate and remove the `arbitrary_self_types` feature gate immediately.
 * Invent a new feature gate.
 
 This RFC proposes the first course of action, since `arbitrary_self_types` is used externally and we think all currently use-cases should continue to work.


### PR DESCRIPTION
Builds upon https://github.com/adetaylor/rfcs/pull/13.

I know that's what we want to achieve, but it also carries a commitment that's not necessarily relevant to the RFC.

I'd also suggest that once you do open the RFC to the wider community, you rename the branch ;)