### PR TITLE
Update reference & deshadowing.

### DIFF
--- a/text/3519-arbitrary-self-types-v2.md
+++ b/text/3519-arbitrary-self-types-v2.md
@@ -568,7 +568,7 @@ impl Vexation {
 }
 
 fn main {
-    let v = Vec::new();
+    let mut v = Vec::new();
     v.push(Vexation);
     v.do_something_to_vec(); // this seems weird and I can't imagine a use-case
 

--- a/text/3519-arbitrary-self-types-v2.md
+++ b/text/3519-arbitrary-self-types-v2.md
@@ -248,7 +248,7 @@ Specifically, instead of using the list of candidate types assembled using the `
 
 It's particularly important to emphasize that the list of candidate receiver types _does not change_ - that's still assembled using the `Deref` trait just as now. But, a wider set of locations is searched for methods with those receiver types.
 
-For instance, `Weak<T>` implements `Receiver` but not `Deref`. Imagine you have `let t: Weak<SomeStruct> = /* obtain */; t.some_method();`. We will now search `impl SomeStruct {}` blocks for an implementation of `fn some_method(self: Weak<SomeStruct>)`, `fn some_method(self: &Weak<SomeStruct>)`, etc. The possible self types are unchanged - they're still obtained by searching the `Deref` chain for `t` - but we'll look in more places for methods with those valid `self` types.
+For instance, `Weak<T>` implements `Receiver` but not `Deref`. Imagine you have `let t: Weak<SomeStruct> = /* obtain */; t.some_method();`. We will now search `impl SomeStruct {}` blocks for an implementation of `fn some_method(self: Weak<SomeStruct>)`, `fn some_method(self: &Weak<SomeStruct>)`, etc. The possible self types in the method call expression are unchanged - they're still obtained by searching the `Deref` chain for `t` - but we'll look in more places for methods with those valid `self` types.
 
 ## Compiler changes: deshadowing
 [compiler-changes-deshadowing]: #compiler-changes-deshadowing

--- a/text/3519-arbitrary-self-types-v2.md
+++ b/text/3519-arbitrary-self-types-v2.md
@@ -307,10 +307,7 @@ The existing branches in the compiler for "arbitrary self types" already emit ex
   }
   ```
   We don't know a use-case for this. There are several cases where this can result in misleading diagnostics. (For instance, if such a method is called with an incorrect type (for example `smart_ptr.a::<&Foo>()` instead of `smart_ptr.a::<Foo>()`). We could attempt to find and fix all those cases. However, we feel that generic receiver types might risk subtle interactions with method resolutions and other parts of the language. We think it is a safer choice to generate an error on any declaration of a generic `self` type.
-- As noted in [#compiler-changes-deshadowing](the section about compiler changes for deshadowing) we will downgrade an existing error to a warning if there are multiple
-  method candidates found, if one of those candidates is further along the chain of `Receiver`s than the others.
-- As also noted in [#compiler-changes-deshadowing](the section about compiler changes for deshadowing), we will produce a new warning if a method in an inner type is chosen in preference to a method in an outer type ("inner" = further along the `Receiver` chain) and the inner type is either `self: &T` or `self: &mut T` and we're choosing it in preference to `self: T` or `self: &T` in the outer type. An example warning might be:
-
+- As noted in [#compiler-changes-deshadowing](the section about compiler changes for deshadowing) we will downgrade an existing error to a warning if there are multiple method candidates found, if one of those candidates is further along the chain of `Receiver`s than the others. An example warning might be:
   ```
   warning[W0666]: ambiguous function call
    --> src/main.rs:13:4
@@ -337,6 +334,7 @@ The existing branches in the compiler for "arbitrary self types" already emit ex
     = help: call as a function not a method:
     ~       Weak::retrograde(orbit_weak)
   ```
+- As also noted in [#compiler-changes-deshadowing](the section about compiler changes for deshadowing), we will produce a new warning if a method in an inner type is chosen in preference to a method in an outer type ("inner" = further along the `Receiver` chain) and the inner type is either `self: &T` or `self: &mut T` and we're choosing it in preference to `self: T` or `self: &T` in the outer type. (The warning would be very similar to the above.)
 
 # Drawbacks
 [drawbacks]: #drawbacks

--- a/text/3519-arbitrary-self-types-v2.md
+++ b/text/3519-arbitrary-self-types-v2.md
@@ -555,6 +555,30 @@ Even if the reader takes the view that all calls into foreign languages are intr
 
 A previous PR based on the `Deref` alternative has been proposed before https://github.com/rust-lang/rfcs/pull/2362 and was postponed with the expectation that the lang team would [get back to `arbitrary_self_types` eventually](https://github.com/rust-lang/rfcs/pull/2362#issuecomment-527306157).
 
+# Future work
+
+We could consider implementing `Receiver` for other types, e.g. [`std::cell`](https://doc.rust-lang.org/std/cell/index.html) types, [`std::sync`](https://doc.rust-lang.org/std/sync/index.html) types, [`std::cmp::Reverse`](https://doc.rust-lang.org/std/cmp/struct.Reverse.html), [`std::num::Wrapping`](https://doc.rust-lang.org/nightly/std/num/struct.Wrapping.html), [`std::mem::MaybeUninit`](https://doc.rust-lang.org/std/mem/union.MaybeUninit.html), [`std::task::Poll`](https://doc.rust-lang.org/nightly/std/task/enum.Poll.html), and so on - possibly even for arrays, `Vec`, `BTreeSet` etc.
+
+There seems to be no disadvantage to doing this - taking `Vec` as an example, it would only have any effect on the behavior of code if somebody implemented a method taking `Vec<T>` as a receiver. On the other hand, it's hard to imagine use-cases for some of these. It seems best to consider these future possibilities based on whether the end-result seems natural or strange.
+
+```rust
+impl Vexation {
+    fn do_something_to_vec(self: Vec<Self>) { }
+    fn do_something_to_maybeuninit(self: MaybeUninit<Self>) {}
+}
+
+fn main {
+    let v = Vec::new();
+    v.push(Vexation);
+    v.do_something_to_vec(); // this seems weird and I can't imagine a use-case
+
+    let mut m = MaybeUninit::<Vexation>::uninit();
+    m.do_something_to_maybeuninit(); // this seems fine and useful and so maybe we should in future implement Receiver for MaybeUninit
+}
+```
+
+For now, though, we should clearly restrict `Receiver` to those types for which there's a demonstrated need.
+
 # Feature gates
 
 This RFC is in an unusual position regarding feature gates. There are two existing gates:


### PR DESCRIPTION
This changes the RFC in two significant ways:

* As requested widely, it now proposes that we implement Receiver for NonNull<T> and Weak<T>. This requires us, for the first time, to add explicit code to spot potentially shadowed methods and avoid such shadowing. This is described.
* It expands the Reference section to describe changes to the probing algorithm, which are now a little more extensive than the previous version of the RFC described, because we now search two different chains - one for types into which the receiver can be converted, and another chain for locations to search for possible methods.